### PR TITLE
Allow detectApiVersion to use a custom path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed the `UNKNOWN_JIRA_API_VERSION` validation issue when hostname contains
+  nesting.
+
 ## 3.2.0 - 2022-10-19
 
 ## Changed

--- a/src/jira/__recordings__/withCustomPath_1423265377/recording.har
+++ b/src/jira/__recordings__/withCustomPath_1423265377/recording.har
@@ -1,0 +1,284 @@
+{
+  "log": {
+    "_recordingName": "withCustomPath",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "d46a8721064ddcaea39e77978c1b9087",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8080"
+            }
+          ],
+          "headersSize": 218,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://localhost:8080/test/rest/api/3/serverInfo"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/html;charset=UTF-8",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "name": "atlassian.xsrf.token",
+              "path": "/test",
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/test",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "x-arequestid",
+              "value": "538x206x1"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "frame-ancestors 'self'"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "x-ausername",
+              "value": "anonymous"
+            },
+            {
+              "name": "location",
+              "value": "/test/login.jsp?os_destination=http%3A%2F%2Flocalhost%3A8080%2Ftest%2Frest%2Fapi%2F3%2FserverInfo"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 06 Dec 2022 08:58:41 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 704,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/test/login.jsp?os_destination=http%3A%2F%2Flocalhost%3A8080%2Ftest%2Frest%2Fapi%2F3%2FserverInfo",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2022-12-06T08:58:41.023Z",
+        "time": 87,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 87
+        }
+      },
+      {
+        "_id": "89b30f0f0bb28ade4c42ce6a269b71de",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8080"
+            }
+          ],
+          "headersSize": 218,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://localhost:8080/test/rest/api/2/serverInfo"
+        },
+        "response": {
+          "bodySize": 315,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 315,
+            "text": "{\"baseUrl\":\"http://localhost:8080/test\",\"version\":\"8.20.1\",\"versionNumbers\":[8,20,1],\"deploymentType\":\"Server\",\"buildNumber\":820001,\"buildDate\":\"2021-10-28T00:00:00.000+0000\",\"databaseBuildNumber\":820001,\"scmInfo\":\"6d4b94dbcc29d26a5651b231dd69e39cd4357315\",\"serverTitle\":\"JIRA\"}"
+          },
+          "cookies": [
+            {
+              "name": "atlassian.xsrf.token",
+              "path": "/test",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "x-arequestid",
+              "value": "538x207x1"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "sandbox"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "x-ausername",
+              "value": "anonymous"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, no-transform"
+            },
+            {
+              "name": "vary",
+              "value": "User-Agent"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 06 Dec 2022 08:58:41 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 608,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-12-06T08:58:41.118Z",
+        "time": 80,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 80
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/jira/detectApiVersion.test.ts
+++ b/src/jira/detectApiVersion.test.ts
@@ -67,4 +67,23 @@ describe(detectApiVersion, () => {
       }),
     ).rejects.toThrow('Could not detect the Jira server version');
   });
+
+  test('with custom path', async () => {
+    recording = setupJiraRecording({
+      directory: __dirname,
+      name: 'withCustomPath',
+      options: {
+        recordFailedRequests: true,
+      },
+    });
+
+    await expect(
+      detectApiVersion({
+        protocol: normalizedLocalServerInstanceConfig.protocol,
+        host: normalizedLocalServerInstanceConfig.host,
+        port: normalizedLocalServerInstanceConfig.port,
+        base: 'test',
+      }),
+    ).resolves.toEqual('2');
+  });
 });

--- a/src/jira/detectApiVersion.ts
+++ b/src/jira/detectApiVersion.ts
@@ -20,14 +20,18 @@ const VERSION_DETECTIONS = {
  * that this does not require authentication.
  */
 export async function detectApiVersion(
-  apiOptions: Required<Pick<JiraApiOptions, 'protocol' | 'host' | 'port'>>,
+  apiOptions: Required<Pick<JiraApiOptions, 'protocol' | 'host' | 'port'>> & {
+    base?: string;
+  },
 ): Promise<JiraApiVersion> {
   const errors: Error[] = [];
 
   for (const version of KNOWN_JIRA_API_VERSIONS) {
     try {
       const response = await fetch(
-        `${apiOptions.protocol}://${apiOptions.host}:${apiOptions.port}/rest/api/${version}/serverInfo`,
+        `${apiOptions.protocol}://${apiOptions.host}:${apiOptions.port}${
+          apiOptions.base ? `/${apiOptions.base}` : ''
+        }/rest/api/${version}/serverInfo`,
         {
           follow: 0,
         },

--- a/src/jira/detectApiVersion.ts
+++ b/src/jira/detectApiVersion.ts
@@ -28,14 +28,14 @@ export async function detectApiVersion(
 
   for (const version of KNOWN_JIRA_API_VERSIONS) {
     try {
-      const response = await fetch(
-        `${apiOptions.protocol}://${apiOptions.host}:${apiOptions.port}${
-          apiOptions.base ? `/${apiOptions.base}` : ''
-        }/rest/api/${version}/serverInfo`,
-        {
-          follow: 0,
-        },
-      );
+      const base = `${apiOptions.protocol}://${apiOptions.host}:${apiOptions.port}`;
+      const url = apiOptions.base
+        ? `${base}/${apiOptions.base}/rest/api/${version}/serverInfo`
+        : `${base}/rest/api/${version}/serverInfo`;
+
+      const response = await fetch(url, {
+        follow: 0,
+      });
       if (response.headers.get('content-type')?.match(/application\/json/)) {
         const info = (await response.json()) as ServerInfo;
         if (VERSION_DETECTIONS[version](response.status, info)) {

--- a/src/jira/types.ts
+++ b/src/jira/types.ts
@@ -48,7 +48,7 @@ export type JiraHostConfig = Required<
   Pick<JiraApiOptions, 'protocol' | 'port'>
 > & {
   host: JiraHostString;
-  base: string | undefined;
+  base?: string;
 };
 
 /**


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

<!-- Summary here! -->

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
